### PR TITLE
clap -> gumdrop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ travis-ci = { repository = "psurply/dwfv" }
 lalrpop = { version = "0.18", features = ["lexer"] }
 
 [dependencies]
-clap = "2"
+gumdrop = "0.8"
 lalrpop-util = "0.18"
 lazy_static = "1"
 regex = "1"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ DWFV
 A simple digital waveform viewer with vi-like key bindings.
 
 ```shell
-$ dwfv sample.vcd
+$ dwfv -i sample.vcd
 ```
 
 ![screenshot](docs/screenshot.png)
@@ -99,7 +99,7 @@ Command-Line Interface
 ### Show some stats about the VCD file
 
 ```shell
-$ dwfv examples/sample.vcd stats
+$ dwfv -i examples/sample.vcd stats
 test
   ! (value) - width: 8, edges: 37, from: 0, to: 1010
   " (clk) - width: 1, edges: 102, from: 0, to: 1010
@@ -113,7 +113,7 @@ test
 ### Display values of the signal at a given time
 
 ```shell
-$ dwfv sample.vcd at 42
+$ dwfv -i sample.vcd at 42
 test
   ! (value) = h07
   " (clk) -> h0
@@ -127,10 +127,10 @@ test
 ### Search in the waveforms
 
 ```shell
-$ dwfv sample.vcd when '$! = 2'
+$ dwfv -i sample.vcd when '$! = 2'
 310-330
 650-670
-$ dwfv sample.vcd when '$! <- 4'
+$ dwfv -i sample.vcd when '$! <- 4'
 350
 690
 ```


### PR DESCRIPTION
I replaced `clap` with `gumdrop` for argument parsing. This does change the semantics for CLI usage slightly. For example, the input file is now passed with the `-i` option, and commands can be described with `at --help`, `stats --help`, and `when --help`. Otherwise I tried to keep usage as close as possible.

This change makes the binary about 500 KiB smaller. Before-and-after for release builds on my machine:

```
# Before
-rwxr-xr-x  2 parasyte  staff  2686844 May 31 00:52 target/release/dwfv*

# After
-rwxr-xr-x  2 parasyte  staff  2162164 May 31 03:25 target/release/dwfv*
```