### PR TITLE
Remove regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,6 @@ travis-ci = { repository = "psurply/dwfv" }
 
 [dependencies]
 gumdrop = "0.8"
-lazy_static = "1"
 nom = { version = "5.1", default-features = false, features = ["std"] }
-regex = "1"
 tui = "0.9"
 termion = "1.5"


### PR DESCRIPTION
The last big dependency is `regex`. This PR replaces it with simple iterator-based parsing.

<details><summary>Before:</summary>

```
$ cargo build --release
    Finished release [optimized] target(s) in 41.39s

$ ls -l target/release/dwfv
-rwxr-xr-x  2 parasyte  staff  2107908 Jun 13 00:21 target/release/dwfv*

$ cargo tree
dwfv v0.3.0 (/Users/parasyte/other-projects/dwfv)
├── gumdrop v0.8.0
│   └── gumdrop_derive v0.8.0
│       ├── proc-macro2 v1.0.18
│       │   └── unicode-xid v0.2.0
│       ├── quote v1.0.6
│       │   └── proc-macro2 v1.0.18 (*)
│       └── syn v1.0.30
│           ├── proc-macro2 v1.0.18 (*)
│           ├── quote v1.0.6 (*)
│           └── unicode-xid v0.2.0
├── lazy_static v1.4.0
├── nom v5.1.1
│   └── memchr v2.3.3
│   [build-dependencies]
│   └── version_check v0.9.2
├── regex v1.3.9
│   ├── aho-corasick v0.7.10
│   │   └── memchr v2.3.3
│   ├── memchr v2.3.3
│   ├── regex-syntax v0.6.18
│   └── thread_local v1.0.1
│       └── lazy_static v1.4.0
├── termion v1.5.5
│   ├── libc v0.2.71
│   └── numtoa v0.1.0
└── tui v0.9.5
    ├── bitflags v1.2.1
    ├── cassowary v0.3.0
    ├── either v1.5.3
    ├── itertools v0.9.0
    │   └── either v1.5.3
    ├── termion v1.5.5 (*)
    ├── unicode-segmentation v1.6.0
    └── unicode-width v0.1.7
```
</details>

<details><summary>After:</summary>

```
$ cargo build --release
    Finished release [optimized] target(s) in 27.62s

$ ls -l target/release/dwfv
-rwxr-xr-x  2 parasyte  staff  965044 Jun 13 00:23 target/release/dwfv*

$ cargo tree
dwfv v0.3.0 (/Users/parasyte/other-projects/dwfv)
├── gumdrop v0.8.0
│   └── gumdrop_derive v0.8.0
│       ├── proc-macro2 v1.0.18
│       │   └── unicode-xid v0.2.0
│       ├── quote v1.0.6
│       │   └── proc-macro2 v1.0.18 (*)
│       └── syn v1.0.30
│           ├── proc-macro2 v1.0.18 (*)
│           ├── quote v1.0.6 (*)
│           └── unicode-xid v0.2.0
├── nom v5.1.1
│   └── memchr v2.3.3
│   [build-dependencies]
│   └── version_check v0.9.2
├── termion v1.5.5
│   ├── libc v0.2.71
│   └── numtoa v0.1.0
└── tui v0.9.5
    ├── bitflags v1.2.1
    ├── cassowary v0.3.0
    ├── either v1.5.3
    ├── itertools v0.9.0
    │   └── either v1.5.3
    ├── termion v1.5.5 (*)
    ├── unicode-segmentation v1.6.0
    └── unicode-width v0.1.7
```
</details>

Highlights:

- Release profile compiles 44% faster (1.51x speed increase)
- Release executable is 55% smaller (1.14 MiB smaller)
- 8 fewer dependencies total