### PR TITLE
scope: store signals and scopes in different namespaces

### DIFF
--- a/src/signaldb/db.rs
+++ b/src/signaldb/db.rs
@@ -455,7 +455,9 @@ impl SignalDB {
         }
         {
             let mut signals = self.signals.lock().unwrap();
-            signals.insert(signal.id.clone(), signal);
+            if signals.get(&signal.id).is_none() {
+                signals.insert(signal.id.clone(), signal);
+            }
         }
     }
 
@@ -1247,8 +1249,8 @@ impl SignalDB {
             }
             match node {
                 ScopeChild::Signal => signals.get(name).unwrap().format_stats(output),
-                ScopeChild::Scope(scope) => {
-                    let _ = writeln!(output, "{}", scope.name);
+                ScopeChild::Scope => {
+                    let _ = writeln!(output, "{}", name);
                 }
             }
         })
@@ -1290,8 +1292,8 @@ impl SignalDB {
                     .get(name)
                     .unwrap()
                     .format_value_at(output, timestamp),
-                ScopeChild::Scope(scope) => {
-                    let _ = writeln!(output, "{}", scope.name);
+                ScopeChild::Scope => {
+                    let _ = writeln!(output, "{}", name);
                 }
             }
         })


### PR DESCRIPTION
In the data structure used to represent the signal scopes, the sub-scopes
and the signal IDs were stored in the same BTreeMap which led to name
conflicts in some cases. For example:

    $ cat input.vcd
    ...
    $scope module top $end
        $var wire 1 A foo $end
        $scope module A $end
    ...
    $ dwfv input.vcd
    thread '<unnamed>' panicked at 'Specified path is a signal, not a scope', dwfv-0.4.0/src/signaldb/scope.rs:49:18
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Fixes #9

Signed-off-by: Pierre Surply <pierre.surply@gmail.com>