### PR TITLE
Fix compiler warning

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -751,7 +751,7 @@ impl App {
             } else {
                 buf.push_str(&format!("{}, ", instr))
             }
-        };
+        }
 
         let mut s = String::new();
         let mut counter = 1;


### PR DESCRIPTION
Fixes a warn(redundant_semicolons).

```
warning: unnecessary trailing semicolon
   --> src/tui/app.rs:754:10
    |
754 |         };
    |          ^ help: remove this semicolon
    |
    = note: `#[warn(redundant_semicolons)]` on by default
```