### PR TITLE
Allow the crate to be used as a library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,14 @@ exclude = [
 [badges]
 travis-ci = { repository = "psurply/dwfv" }
 
+[features]
+default = ["cli"]
+cli = ["gumdrop", "tui", "termion"]
+
 [dependencies]
-gumdrop = "0.8"
 nom = { version = "5.1", default-features = false, features = ["std"] }
-tui = "0.9"
-termion = "1.5"
+
+# For feature `cli`
+gumdrop = { version = "0.8", optional = true }
+tui = { version = "0.9", optional = true }
+termion = { version = "1.5", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@
 
 mod search;
 pub mod signaldb;
+#[cfg(feature = "cli")]
 pub mod tui;
 mod vcd;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "cli")]
+
 // SPDX-License-Identifier: MIT
 use dwfv::signaldb::{AsyncSignalDB, SignalDB};
 use dwfv::tui::Tui;


### PR DESCRIPTION
This adds a default feature flag that can be disabled to allow dependents to use the crate as a library without pulling in the transitive dependencies that are only used for the TUI.

This is especially useful on Windows, because `termion` does not build at all on the platform.

Tests pass on Windows when running with `cargo test --no-default-features`.