### PR TITLE
Add basic support for parsing $dumpall, $dumpon, and $dumpoff

### DIFF
--- a/src/vcd/lexer.rs
+++ b/src/vcd/lexer.rs
@@ -8,6 +8,9 @@ use std::str::FromStr;
 pub(crate) enum Keyword {
     Comment,
     Date,
+    DumpAll,
+    DumpOff,
+    DumpOn,
     DumpVars,
     End,
     EndDefinitions,
@@ -55,6 +58,9 @@ impl Token {
         let kw = match word {
             "$comment" => Some(Keyword::Comment),
             "$date" => Some(Keyword::Date),
+            "$dumpall" => Some(Keyword::DumpAll),
+            "$dumpoff" => Some(Keyword::DumpOff),
+            "$dumpon" => Some(Keyword::DumpOn),
             "$dumpvars" => Some(Keyword::DumpVars),
             "$end" => Some(Keyword::End),
             "$enddefinitions" => Some(Keyword::EndDefinitions),

--- a/src/vcd/parser.rs
+++ b/src/vcd/parser.rs
@@ -213,7 +213,9 @@ impl<'a, I: BufRead> Parser<'a, I> {
                         self.signaldb.mark_as_initialized();
                         self.parse_comment()?
                     }
-                    Keyword::DumpVars => self.parse_dumpvars()?,
+                    Keyword::DumpAll | Keyword::DumpOff | Keyword::DumpOn | Keyword::DumpVars => {
+                        self.parse_dumpvars()?
+                    }
                     Keyword::Scope => self.parse_scope()?,
                     Keyword::Var => self.parse_var()?,
                     Keyword::Upscope => self.parse_upscope()?,


### PR DESCRIPTION
I have a simulation run by Icarus Verilog that outputs a VCD with an empty `$dumpall` section. While trying to understand what it was, I also found references to `$dumpon` and `$dumpoff`. Other VCD parsers like pyvcd parse them.

This just treats these keywords like `$dumpvars`.